### PR TITLE
bootstrap: fix setup-bootdev script execution problem

### DIFF
--- a/bootstrap/module.mk
+++ b/bootstrap/module.mk
@@ -134,7 +134,7 @@ $(BUILD_DIR)/bootstrap/customize-initram-root.done: \
 	sudo cp -r $(BUILD_DIR)/repos/nailgun/bin/send2syslog.py $(INITRAMROOT)/usr/bin
 
 	# Enabling pre-init boot interface discovery
-	sudo chroot $(INITRAMROOT) chkconfig setup-bootdev on
+	sudo chroot $(INITRAMROOT) systemctl enable setup-bootdev.service
 
 	# Setting root password into r00tme
 	sudo sed -i -e '/^root/c\root:$$6$$oC7haQNQ$$LtVf6AI.QKn9Jb89r83PtQN9fBqpHT9bAFLzy.YVxTLiFgsoqlPY3awKvbuSgtxYHx4RUcpUqMotp.WZ0Hwoj.:15441:0:99999:7:::' $(INITRAMROOT)/etc/shadow

--- a/bootstrap/sync/etc/systemd/system/setup-bootdev.service
+++ b/bootstrap/sync/etc/systemd/system/setup-bootdev.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Fuel Setup Network Interface Script
+Before=network.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/setup-bootdev
+
+[Install]
+WantedBy=multi-user.target

--- a/bootstrap/sync/usr/bin/setup-bootdev
+++ b/bootstrap/sync/usr/bin/setup-bootdev
@@ -50,43 +50,35 @@ set_interfaces_up_when_booted() {
     done
 }
 
-# See how we were called.
-case "$1" in
-  start)
-    echo -n "Configure all interfaces as active..."
-    set_interfaces_up_when_booted
-    echo "ok."
-    echo -n "Obtain boot interface name..."
-    dev=$(get_bootdev)
-    rc=$?
+echo -n "Configure all interfaces as active..."
+set_interfaces_up_when_booted
+echo "ok."
+echo -n "Obtain boot interface name..."
+dev=$(get_bootdev)
+rc=$?
 
-    if [ $rc -ne 0 ]; then
+if [ $rc -ne 0 ]; then
+    echo "failed."
+    echo -en "Obtain all eth interfaces..."
+    dev=$(get_alldevs)
+    if [ -z "$dev" ]; then
+        rc=1
         echo "failed."
-        echo -en "Obtain all eth interfaces..."
-        dev=$(get_alldevs)
-        if [ -z "$dev" ]; then
-            rc=1
-            echo "failed."
-        else
-            rc=0
-            dev_str=$(echo "$dev"|tr "\n" " "|sed 's/ *$//')
-            echo "ok ($dev_str)."
-        fi
     else
-        echo "ok ($dev)."
+        rc=0
+        dev_str=$(echo "$dev"|tr "\n" " "|sed 's/ *$//')
+        echo "ok ($dev_str)."
     fi
+else
+    echo "ok ($dev)."
+fi
 
-    if [ $rc -eq 0 ]; then
-        for name in $dev; do
-            content="DEVICE=$name\nBOOTPROTO=dhcp\nONBOOT=yes\nLINKDELAY=30"
-            echo -e "$content" > "./ifcfg-$name"
-        done
-    fi
-    action $"Update network interfaces settings: " [ $rc -eq 0 ]
-    ;;
-  *)
-    rc=0
-    ;;
-esac
+if [ $rc -eq 0 ]; then
+    for name in $dev; do
+        content="DEVICE=$name\nBOOTPROTO=dhcp\nONBOOT=yes\nLINKDELAY=30"
+        echo -e "$content" > "./ifcfg-$name"
+    done
+fi
+action $"Update network interfaces settings: " [ $rc -eq 0 ]
 
 exit $rc


### PR DESCRIPTION
The "/etc/init.d/setup-bootdev start" execution would be redirected by
systemd and failed. So we invoke the script in the systemd way.

Fixes: redmine #3185

Signed-off-by: huntxu mhuntxu@gmail.com
