### PR TITLE
Fix rc.local for boostrap based on CentOS 7

### DIFF
--- a/bootstrap/sync/etc/rc.d/rc.local
+++ b/bootstrap/sync/etc/rc.d/rc.local
@@ -1,8 +1,6 @@
 #!/bin/sh -e
 
-mount -t devpts devpts /dev/pts
-
 fix-configs-on-startup || true
-flock -w 0 -o /var/lock/agent.lock -c "/opt/nailgun/bin/agent >> /var/log/nailgun-agent.log 2>&1" || true
+flock -n -o /var/lock/agent.lock -c "/opt/nailgun/bin/agent >> /var/log/nailgun-agent.log 2>&1" || true
 
 touch /var/lock/subsys/local


### PR DESCRIPTION
Systemd reports failed to start /etc/rc.d/rc.local compatibility, this
commit fixes the problem.

Devpts is already mounted on /dev/pts on CentOS 7, so simply don't do
that again in the rc.local script.

For flock, "-w 0" is no longer a synonym for "-n" in the version we now
use on CentOS 7.

Fixes: redmine #3202

Signed-off-by: huntxu mhuntxu@gmail.com
