### PR TITLE
make it's possible to start fuelmenu during systemd boot for CentOS 7.

### DIFF
--- a/iso/bootstrap_admin_node.service
+++ b/iso/bootstrap_admin_node.service
@@ -1,11 +1,21 @@
 [Unit]
 Description=Fuel Bootstrap Script
-After=rc-local.service
-Before=getty.target
+After=plymouth-quit-wait.service systemd-vconsole-setup.service
+Before=getty@tty1.service getty@ttyUSB0.service
+Before=serial-getty@ttyS0.service serial-getty@ttyO0.service serial-getty@ttyO2.service
+Before=serial-getty@ttyAMA0.service serial-getty@ttymxc0.service serial-getty@ttymxc3.service
+Conflicts=plymouth-quit-wait.service
 
 [Service]
 Type=oneshot
+ExecStartPre=-/bin/plymouth quit
+ExecStartPre=/bin/kill -55 1
 ExecStart=/usr/sbin/bootstrap_admin_node
+ExecStartPost=/bin/kill -54 1
+RemainAfterExit=yes
+StandardInput=tty
+StandardOutput=inherit
+StandardError=inherit
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
this solution comes from:
https://github.com/rhinstaller/initial-setup/blob/master/systemd/initial-setup-text.service

Signed-off-by: Zhao Chao zhaochao1984@gmail.com
