### PR TITLE
Fix workaround for ostf-server's requirement of gevent==0.13.8.

### DIFF
--- a/docker/ostf/start.sh
+++ b/docker/ostf/start.sh
@@ -8,10 +8,10 @@ rpm --rebuilddb
 #Workaround for facter to detect docker
 grep -q '/system.slice/dock' /proc/1/cgroup && sed -i 's/\/docker\//\/system\.slice\/docker/' /usr/share/ruby/vendor_ruby/facter/util/virtual.rb
 
-puppet apply -v /etc/puppet/modules/nailgun/examples/ostf-only.pp
-
 #Workaround to pass python packages version dependencies
 sed -i 's/gevent==0.13.8/gevent>=0.13.8/' /usr/lib/python2.7/site-packages/fuel_ostf-*.egg-info/requires.txt
+
+puppet apply -v /etc/puppet/modules/nailgun/examples/ostf-only.pp
 
 pgrep supervisord >/dev/null && /usr/bin/supervisorctl shutdown
 while pgrep supervisord >/dev/null; do sleep 1; done


### PR DESCRIPTION
The workaround was not working perfectly because ostf-only.pp also calls
ostf-server, so it should ran before puppet apply.

Signed-off-by: Zhao Chao zhaochao1984@gmail.com
